### PR TITLE
Define MICROPY_INCLUDED_PY_MPSTATE_H defore include lv_gc.h

### DIFF
--- a/ports/esp32/mpconfigport.h
+++ b/ports/esp32/mpconfigport.h
@@ -258,7 +258,13 @@ extern void lv_deinit(void);
 struct _machine_timer_obj_t;
 
 #if MICROPY_PY_LVGL
+#ifndef MICROPY_INCLUDED_PY_MPSTATE_H
+#define MICROPY_INCLUDED_PY_MPSTATE_H
 #include "lib/lv_bindings/lvgl/src/lv_misc/lv_gc.h"
+#undef MICROPY_INCLUDED_PY_MPSTATE_H
+#else
+#include "lib/lv_bindings/lvgl/src/lv_misc/lv_gc.h"
+#endif
 #else
 #define LV_ROOTS
 #endif

--- a/ports/javascript/mpconfigport.h
+++ b/ports/javascript/mpconfigport.h
@@ -178,7 +178,13 @@ extern const struct _mp_obj_module_t mp_module_SDL;
 extern const struct _mp_obj_module_t mp_module_lodepng;
 
 #if MICROPY_PY_LVGL
+#ifndef MICROPY_INCLUDED_PY_MPSTATE_H
+#define MICROPY_INCLUDED_PY_MPSTATE_H
 #include "lib/lv_bindings/lvgl/src/lv_misc/lv_gc.h"
+#undef MICROPY_INCLUDED_PY_MPSTATE_H
+#else
+#include "lib/lv_bindings/lvgl/src/lv_misc/lv_gc.h"
+#endif
 #define MICROPY_PY_LVGL_DEF \
     { MP_OBJ_NEW_QSTR(MP_QSTR_lvgl), (mp_obj_t)&mp_module_lvgl },\
     { MP_OBJ_NEW_QSTR(MP_QSTR_lvindev), (mp_obj_t)&mp_module_lvindev},\

--- a/ports/stm32/mpconfigport.h
+++ b/ports/stm32/mpconfigport.h
@@ -311,7 +311,13 @@ extern const struct _mp_obj_module_t mp_module_lodepng;
 #define MP_STATE_PORT MP_STATE_VM
 
 #if MICROPY_PY_LVGL
+#ifndef MICROPY_INCLUDED_PY_MPSTATE_H
+#define MICROPY_INCLUDED_PY_MPSTATE_H
 #include "lib/lv_bindings/lvgl/src/lv_misc/lv_gc.h"
+#undef MICROPY_INCLUDED_PY_MPSTATE_H
+#else
+#include "lib/lv_bindings/lvgl/src/lv_misc/lv_gc.h"
+#endif
 #else
 #define LV_ROOTS
 #endif

--- a/ports/unix/mpconfigport.h
+++ b/ports/unix/mpconfigport.h
@@ -259,7 +259,13 @@ extern const struct _mp_obj_module_t mp_module_lodepng;
 #endif
 
 #if MICROPY_PY_LVGL
+#ifndef MICROPY_INCLUDED_PY_MPSTATE_H
+#define MICROPY_INCLUDED_PY_MPSTATE_H
 #include "lib/lv_bindings/lvgl/src/lv_misc/lv_gc.h"
+#undef MICROPY_INCLUDED_PY_MPSTATE_H
+#else
+#include "lib/lv_bindings/lvgl/src/lv_misc/lv_gc.h"
+#endif
 #define MICROPY_PY_LVGL_DEF { MP_OBJ_NEW_QSTR(MP_QSTR_lvgl), (mp_obj_t)&mp_module_lvgl },
     #if MICROPY_PY_LVGL_SDL
     #define MICROPY_PY_LVGL_SDL_DEF { MP_OBJ_NEW_QSTR(MP_QSTR_SDL), (mp_obj_t)&mp_module_SDL },

--- a/ports/windows/mpconfigport.h
+++ b/ports/windows/mpconfigport.h
@@ -162,7 +162,13 @@ extern const struct _mp_obj_module_t mp_module_SDL;
 extern const struct _mp_obj_module_t mp_module_lodepng;
 
 #if MICROPY_PY_LVGL
+#ifndef MICROPY_INCLUDED_PY_MPSTATE_H
+#define MICROPY_INCLUDED_PY_MPSTATE_H
 #include "lib/lv_bindings/lvgl/src/lv_misc/lv_gc.h"
+#undef MICROPY_INCLUDED_PY_MPSTATE_H
+#else
+#include "lib/lv_bindings/lvgl/src/lv_misc/lv_gc.h"
+#endif
 #define MICROPY_PY_LVGL_DEF { MP_OBJ_NEW_QSTR(MP_QSTR_lvgl), (mp_obj_t)&mp_module_lvgl },
     #if MICROPY_PY_LVGL_SDL
     #define MICROPY_PY_LVGL_SDL_DEF { MP_OBJ_NEW_QSTR(MP_QSTR_SDL), (mp_obj_t)&mp_module_SDL },


### PR DESCRIPTION
to avoid the recursived inclusion