### PR TITLE
LittlevGL --> LVGL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,7 +20,7 @@
 	url = https://github.com/NordicSemiconductor/nrfx.git
 [submodule "lib/lv_bindings"]
 	path = lib/lv_bindings
-	url = https://github.com/littlevgl/lv_bindings.git
+	url = https://github.com/lvgl/lv_binding_micropython.git
 [submodule "lib/mbedtls"]
 	path = lib/mbedtls
 	url = https://github.com/ARMmbed/mbedtls.git

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 ![Build lv_micropython unix port](https://github.com/lvgl/lv_micropython/workflows/Build%20lv_micropython%20unix%20port/badge.svg)
 ![Build lv_micropython stm32 port](https://github.com/lvgl/lv_micropython/workflows/Build%20lv_micropython%20stm32%20port/badge.svg)
 
-**For information abound Micropython lvgl bindings please refrer to [lv_bindings/README.md](https://github.com/littlevgl/lv_bindings/blob/master/README.md)**
+**For information abound Micropython lvgl bindings please refrer to [lv_bindings/README.md](https://github.com/lvgl/lv_bindings/blob/master/README.md)**
 
-See also [Micropython + LittlevGL](https://blog.littlevgl.com/2019-02-20/micropython-bindings) blog post.
+See also [Micropython + LittlevGL](https://blog.lvgl.io/2019-02-20/micropython-bindings) blog post. (LittlevGL is LVGL's previous name.)
 For questions and discussions - please use the forum: https://forum.lvgl.io/c/micropython
 
 Original micropython README: https://github.com/micropython/micropython/blob/master/README.md
@@ -14,7 +14,7 @@ Original micropython README: https://github.com/micropython/micropython/blob/mas
 
 1. `sudo apt-get install build-essential libreadline-dev libffi-dev git pkg-config libsdl2-2.0-0 libsdl2-dev python3.8`  
 Python 3 is required, but you can install some other version of python3 instead of 3.8, if needed.
-2. `git clone --recurse-submodules https://github.com/littlevgl/lv_micropython.git`
+2. `git clone --recurse-submodules https://github.com/lvgl/lv_micropython.git`
 3. `cd lv_micropython`
 4. `make -C mpy-cross`
 5. `make -C ports/unix/`
@@ -24,10 +24,10 @@ Python 3 is required, but you can install some other version of python3 instead 
 
 Please set `ESPIDF` parameter for the esp-idf install dir.
 It needs to match Micropython expected esp-idf, otherwise a warning will be displayed (and build will probably fail)
-For more details refer to [Setting up the toolchain and ESP-IDF](https://github.com/littlevgl/lv_micropython/blob/master/ports/esp32/README.md#setting-up-the-toolchain-and-esp-idf)
+For more details refer to [Setting up the toolchain and ESP-IDF](https://github.com/lvgl/lv_micropython/blob/master/ports/esp32/README.md#setting-up-the-toolchain-and-esp-idf)
 
 When using IL9341 driver, the color depth and swap mode need to be set to match ILI9341. This can be done from the command line.
-Here is the command to build ESP32 + LittlevGL which is compatible with ILI9341 driver:
+Here is the command to build ESP32 + LVGL which is compatible with ILI9341 driver:
 
 ```
 make -C mpy-cross
@@ -37,7 +37,7 @@ make -C ports/esp32 LV_CFLAGS="-DLV_COLOR_DEPTH=16 -DLV_COLOR_16_SWAP=1" BOARD=G
 Explanation about the paramters:
 - `LV_CFLAGS` are used to override color depth and swap mode, for ILI9341 compatibility.  
   - `LV_COLOR_DEPTH=16` is needed if you plan to use the ILI9341 driver.
-  - `LV_COLOR_16_SWAP=1` is needed if you plan to use the [Pure Micropython Display Driver](https://blog.littlevgl.com/2019-08-05/micropython-pure-display-driver).
+  - `LV_COLOR_16_SWAP=1` is needed if you plan to use the [Pure Micropython Display Driver](https://blog.lvgl.io/2019-08-05/micropython-pure-display-driver).
 - `BOARD` - I use WROVER board with SPIRAM. You can choose other boards from `ports/esp32/boards/` directory.
 - `deploy` - make command will create ESP32 port of Micropython, and will try to deploy it through USB-UART bridge.
 
@@ -49,7 +49,7 @@ Refer to the README of the `lvgl_javascript` branch: https://github.com/lvgl/lv_
 
 ## Super Simple Example
 
-First, LittlevGL needs to be imported and initialized
+First, LVGL needs to be imported and initialized
 
 ```python
 import lvgl as lv
@@ -57,7 +57,7 @@ lv.init()
 ```
 
 Then display driver and input driver needs to be registered.
-Refer to [Porting the library](https://docs.littlevgl.com/#Porting) for more information.
+Refer to [Porting the library](https://docs.lvgl.io/8.0/porting/index.html) for more information.
 Here is an example of registering SDL drivers on Micropython unix port:
 
 ```python
@@ -131,14 +131,14 @@ lv.scr_load(scr)
 
 ## More information
 
-More info about LittlevGL: 
-- Website https://littlevgl.com
-- GitHub: https://github.com/littlevgl/lvgl
+More info about LVGL: 
+- Website https://lvgl.io
+- GitHub: https://github.com/lvgl/lvgl
 
 More info about lvgl Micropython bindings:
-- https://github.com/littlevgl/lv_bindings/blob/master/README.md
+- https://github.com/lvgl/lv_bindings/blob/master/README.md
 
-Discussions about the Microptyhon binding: https://github.com/littlevgl/lvgl/issues/557
+Discussions about the Microptyhon binding: https://github.com/lvgl/lvgl/issues/557
 
 More info about the unix port: https://github.com/micropython/micropython/wiki/Getting-Started#debian-ubuntu-mint-and-variants
 


### PR DESCRIPTION
As discusssed in [issue #141 of lv_binding_micropython](https://github.com/lvgl/lv_binding_micropython/issues/141)

I put in a "(LittlevGL is LVGL's previous name.)" because of the name of the blog post. 