### PR TITLE
Zephyr OS port: invalid merge of CMakeLists.txt

### DIFF
--- a/ports/zephyr/CMakeLists.txt
+++ b/ports/zephyr/CMakeLists.txt
@@ -25,7 +25,6 @@
 cmake_minimum_required(VERSION 3.13.1)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-<<<<<<< HEAD
 project(micropython)
 
 set(MICROPY_PORT_DIR    ${CMAKE_CURRENT_SOURCE_DIR})
@@ -119,34 +118,3 @@ target_sources(app PRIVATE
 )
 
 target_link_libraries(app PRIVATE ${MICROPY_TARGET})
-=======
-project(NONE)
-
-target_sources(app PRIVATE src/zephyr_start.c src/zephyr_getchar.c)
-
-add_library(libmicropython STATIC IMPORTED)
-set_target_properties(libmicropython PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/libmicropython.a)
-target_link_libraries(app PUBLIC libmicropython)
-target_link_libraries(libmicropython INTERFACE kernel)
-
-target_include_directories(app PRIVATE
-  ${ZEPHYR_BASE}/kernel/include
-  ${ZEPHYR_BASE}/lib
-  ${ZEPHYR_BASE}/arch/${ARCH}/include
-  )
-
-zephyr_get_include_directories_for_lang_as_string(C includes)
-zephyr_get_system_include_directories_for_lang_as_string(C system_includes)
-zephyr_get_compile_definitions_for_lang_as_string(C definitions)
-zephyr_get_compile_options_for_lang_as_string(C options)
-
-add_custom_target(
-  outputexports
-  COMMAND echo CC="${CMAKE_C_COMPILER}"
-  COMMAND echo AR="${CMAKE_AR}"
-  COMMAND echo Z_CFLAGS=${system_includes} ${includes} ${definitions} ${options}
-  VERBATIM
-  USES_TERMINAL
-)
-
->>>>>>> master


### PR DESCRIPTION
Hello,

would it be please possible to update/remerge the CMakeLists.txt in Zephyr port, which have been merged incorrectly?

This PR contains adaptation of Zephyr port's CMakeLists.txt to a state as it is in the main Micropython repository.