### PR TITLE
.github/workflows/ports_esp32.yml added back

### DIFF
--- a/.github/workflows/ports_esp32.yml
+++ b/.github/workflows/ports_esp32.yml
@@ -1,0 +1,36 @@
+name: esp32 port
+
+on:
+  push:
+  pull_request:
+    paths:
+      - '.github/workflows/*.yml'
+      - 'tools/**'
+      - 'py/**'
+      - 'extmod/**'
+      - 'lib/**'
+      - 'drivers/**'
+      - 'ports/esp32/**'
+
+jobs:
+  build_idf402:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Initialize lv_bindings submodule
+      run: git submodule update --init --recursive lib/lv_bindings
+    - name: Install packages
+      run: source tools/ci.sh && ci_esp32_idf402_setup
+    - name: Build
+      run: source tools/ci.sh && ci_esp32_build
+
+  build_idf43:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Initialize lv_bindings submodule
+      run: git submodule update --init --recursive lib/lv_bindings
+    - name: Install packages
+      run: source tools/ci.sh && ci_esp32_idf43_setup
+    - name: Build
+      run: source tools/ci.sh && ci_esp32_build

--- a/tools/ci.sh
+++ b/tools/ci.sh
@@ -110,9 +110,9 @@ function ci_esp32_build {
     make ${MAKEOPTS} -C ports/esp32
     make ${MAKEOPTS} -C ports/esp32 clean
     make ${MAKEOPTS} -C ports/esp32 USER_C_MODULES=../../../examples/usercmodule/micropython.cmake FROZEN_MANIFEST=$(pwd)/ports/esp32/boards/manifest.py
-    if [ -d $IDF_PATH/components/esp32s2 ]; then
-        make ${MAKEOPTS} -C ports/esp32 BOARD=GENERIC_S2
-    fi
+    # if [ -d $IDF_PATH/components/esp32s2 ]; then
+    #     make ${MAKEOPTS} -C ports/esp32 BOARD=GENERIC_S2
+    # fi
 }
 
 ########################################################################################


### PR DESCRIPTION
Updated lv_bindings with espidf.h bugfix

Disabled ESP32-S2 because it is currently not supported by espidh.h
and by native modules that rely on espidf.h such as modrtch.c