### PR TITLE
Add dependency on GNU parallel.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ yacctab.py
 *.swp
 *.swo
 *.swn
+*.swi
+*.swj
+*.swk
+*.swl
+*.swm
 
 # VIM Session Files
 ######################


### PR DESCRIPTION
lv_binding_micropython added a dependency on GNU parallel[1] to allow
the tests to be run in parallel.

[1] https://www.gnu.org/software/parallel/