### PR TITLE
Add dependency on GNU parallel.

### DIFF
--- a/.github/workflows/unix_port.yml
+++ b/.github/workflows/unix_port.yml
@@ -13,11 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Install SDL
+    - name: Install Dependencies
       run: |
         sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"
         sudo apt-get update -y -qq
-        sudo apt-get install libsdl2-dev
+        sudo apt-get install libsdl2-dev parallel
     - name: Initialize lv_bindings submodule
       run: git submodule update --init --recursive lib/lv_bindings
     - name: Update submodules

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,5 +2,5 @@ FROM gitpod/workspace-full-vnc
 
 # Install dependencies
 RUN sudo apt-get update && \
-    sudo apt-get install -y libgtk-3-dev libsdl2-dev x11-xserver-utils
+    sudo apt-get install -y libgtk-3-dev libsdl2-dev x11-xserver-utils parallel
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you are only starting with Micropython+LVGL, it's recommended that you use `l
 
 ## Build Instructions
 
-1. `sudo apt-get install build-essential libreadline-dev libffi-dev git pkg-config libsdl2-2.0-0 libsdl2-dev python3.8`
+1. `sudo apt-get install build-essential libreadline-dev libffi-dev git pkg-config libsdl2-2.0-0 libsdl2-dev python3.8 parallel`
 Python 3 is required, but you can install some other version of python3 instead of 3.8, if needed.
 2. `git clone --recurse-submodules https://github.com/lvgl/lv_micropython.git`
 3. `cd lv_micropython`


### PR DESCRIPTION
lv_binding_micropython added a dependency on GNU parallel[1] to allow
the tests to be run in parallel.

[1] https://www.gnu.org/software/parallel/