### PR TITLE
add CI build for rp2 port (tentative)

### DIFF
--- a/.github/workflows/rp2_port.yml
+++ b/.github/workflows/rp2_port.yml
@@ -1,0 +1,31 @@
+name: Build lv_micropython rp2 port
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        board: [PICO]
+    steps:
+    - uses: actions/checkout@v2
+    - name: arm-none-eabi-gcc
+      uses: fiam/arm-none-eabi-gcc@v1
+      with:
+        release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
+    - name: Update submodules
+      run: git submodule update --init --recursive  
+    - name: Build mpy-cross
+      run: make -j $(nproc) -C mpy-cross
+    - name: Build ${{ matrix.board }}
+      run: make -j $(nproc) -C ports/rp2 BOARD=${{ matrix.board }} USER_C_MODULES=../../lib/lv_bindings/bindings.cmake
+    - uses: actions/upload-artifact@v2
+      if: ${{ env.GITHUB_EVENT_NAME }} == 'push'
+      with:
+        name: ${{ matrix.board }}.hex
+        path: ports/rp2/build-${{ matrix.board }}/firmware.elf

--- a/.github/workflows/rp2_port.yml
+++ b/.github/workflows/rp2_port.yml
@@ -18,8 +18,10 @@ jobs:
       uses: fiam/arm-none-eabi-gcc@v1
       with:
         release: '9-2019-q4' # The arm-none-eabi-gcc release to use.
-    - name: Update submodules
-      run: git submodule update --init --recursive  
+    - name: Initialize lv_bindings submodule
+      run: git submodule update --init --recursive lib/lv_bindings  
+    - name: Initialize Micropython submodules
+      run: make -C ports/rp2 BOARD=${{ matrix.board }} USER_C_MODULES=../../lib/lv_bindings/bindings.cmake submodules
     - name: Build mpy-cross
       run: make -j $(nproc) -C mpy-cross
     - name: Build ${{ matrix.board }}


### PR DESCRIPTION
As requested here: https://github.com/lvgl/lv_micropython/pull/42#issuecomment-915564215 modeled after the stm32 port. I don't know how to test it.