### PR TITLE
Use more efficient set of steps when cloning

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,13 @@ If you are only starting with Micropython+LVGL, it's recommended that you use `l
 
 1. `sudo apt-get install build-essential libreadline-dev libffi-dev git pkg-config libsdl2-2.0-0 libsdl2-dev python3.8 parallel`
 Python 3 is required, but you can install some other version of python3 instead of 3.8, if needed.
-2. `git clone --recurse-submodules https://github.com/lvgl/lv_micropython.git`
+2. `git clone https://github.com/lvgl/lv_micropython.git`
 3. `cd lv_micropython`
-4. `make -C mpy-cross`
-5. `make -C ports/unix/`
-6. `./ports/unix/micropython`
+4. `git submodule update --init --recursive lib/lv_bindings`
+5. `make -C mpy-cross`
+6. `make -C ports/unix submodules`
+7. `make -C ports/unix`
+8. `./ports/unix/micropython`
 
 ### ESP32 port
 


### PR DESCRIPTION
There's no need to clone every submodule (upstream has a lot of them). Just `lib/lv_bindings` and whatever the Unix port depends on should be enough. It also matches the steps [CI uses](https://github.com/lvgl/lv_micropython/blob/d8a68915baa797d02b24f12c2112ff02ac201681/.github/workflows/unix_port.yml#L19-L22).