### PR TITLE
Reduce size of mpy flash filesystem to make room for lvgl

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ This port uses [Micropython infrastructure for C modules](https://docs.micropyth
 5. `make -j -C mpy-cross`
 6. `make -j -C ports/rp2 BOARD=PICO USER_C_MODULES=../../lib/lv_bindings/bindings.cmake`
 
+#### Troubleshooting
+
+If you experience unstable behaviour, it is worth checking the value of *MICROPY_HW_FLASH_STORAGE_BASE* against the value of *__flash_binary_end* from the firmware.elf.map file.
+If the storage base is lower than the binary end, parts of the firmware will be overwritten when the micropython filesystem is initialised.
+
 ## Super Simple Example
 
 First, LVGL needs to be imported and initialized

--- a/ports/rp2/README.md
+++ b/ports/rp2/README.md
@@ -99,3 +99,11 @@ sm.active(1)
 ```
 
 See the `examples/rp2/` directory for further example code.
+
+### Troubleshooting
+
+If you experience unstable behaviour, it is worth checking the value of
+*MICROPY_HW_FLASH_STORAGE_BASE* against the value of *__flash_binary_end*
+from the firmware.elf.map file. If the storage base is lower than the
+binary end, parts of the firmware will be overwritten when the micro-
+python filesystem is initialised.

--- a/ports/rp2/boards/PICO/mpconfigboard.h
+++ b/ports/rp2/boards/PICO/mpconfigboard.h
@@ -1,3 +1,6 @@
 // Board and hardware specific configuration
 #define MICROPY_HW_BOARD_NAME                   "Raspberry Pi Pico"
-#define MICROPY_HW_FLASH_STORAGE_BYTES          (1408 * 1024) 
+// Modified from MPY origin to reduce flash storage to accommodate larger program flash requirement
+// of lvgl and its bindings. Developers should review this setting when adding additional features 
+#define MICROPY_HW_FLASH_STORAGE_BYTES          (1024 * 1024)
+


### PR DESCRIPTION
Please see discussion at:

https://forum.lvgl.io/t/lv-micropython-crashing-on-rp2040-pico-board/8282

Note this change is on a branch to allow it to be promoted independently of upcoming driver contributions.