### PR TITLE
Updated README.md - update Unix (Mac OS) port instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ Python 3 is required, but you can install some other version of python3 instead 
 5. `sudo mkdir -p /usr/local/lib/`
 6. `sudo cp /opt/homebrew/Cellar/sdl2/2.24.0/lib/libSDL2.dylib /usr/local/lib/`
 7. `sudo cp -r /opt/homebrew/Cellar/sdl2/2.24.0/include /usr/local/`
-8. `sed -i '' 's/ -Werror//' ports/unix/Makefile` Remove -Werror from compiler parameters as Mac fails compilation otherwise
+8. `sed -i '' 's/ -Werror//' ports/unix/Makefile mpy-cross/Makefile` Remove -Werror from compiler parameters as Mac fails compilation otherwise
 9. `make -C mpy-cross`
 10. `make -C ports/unix submodules`
 11. `make -C ports/unix`
-12. `./ports/unix/micropython`
+12. `./ports/unix/build-standard/micropython`
 
 ### ESP32 port
 


### PR DESCRIPTION
- added to step 8 `mpy-cross/Makefile` to remove `-Werror`  
- updated step 12 to find the micropython script in the `build-standard` directory