### PR TITLE
esp32: allow external USER_C_MODULES from command line

### DIFF
--- a/ports/esp32/esp32_common.cmake
+++ b/ports/esp32/esp32_common.cmake
@@ -11,7 +11,7 @@ endif()
 # Include core source components.
 include(${MICROPY_DIR}/py/py.cmake)
 
-set(USER_C_MODULES "${MICROPY_DIR}/user_modules/lv_binding_micropython/micropython.cmake")
+list(APPEND USER_C_MODULES "${MICROPY_DIR}/user_modules/lv_binding_micropython/micropython.cmake")
 
 # CMAKE_BUILD_EARLY_EXPANSION is set during the component-discovery phase of
 # `idf.py build`, so none of the extmod/usermod (and in reality, most of the


### PR DESCRIPTION
### Summary

The esp32 port hardcodes `USER_C_MODULES` to point to `lv_binding_micropython` and breaks the ability to pass in additional user modules via command line. This PR fixes that issue

### Testing

I successfully built the esp32 port both with and without additional user modules
