### PR TITLE
Update workflows implemented by the LVGL team

### DIFF
--- a/.github/workflows/js-port-v9.yml
+++ b/.github/workflows/js-port-v9.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/js-port-v9.yml
+++ b/.github/workflows/js-port-v9.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           persist-credentials: false
           ref: 'lvgl_javascript_v9'

--- a/.github/workflows/merge-to-js.yml
+++ b/.github/workflows/merge-to-js.yml
@@ -5,7 +5,7 @@ on:
       - 'master'
 jobs:
   merge-branch:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Wait for Unix port build to succeed
         uses: fountainhead/action-wait-for-check@v1.0.0

--- a/.github/workflows/rp2_port.yml
+++ b/.github/workflows/rp2_port.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         board: [PICO]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: arm-none-eabi-gcc
       uses: carlosperate/arm-none-eabi-gcc-action@v1.3.0
       with:

--- a/.github/workflows/rp2_port.yml
+++ b/.github/workflows/rp2_port.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        board: [PICO]
+        board: [RPI_PICO]
     steps:
     - uses: actions/checkout@v4
     - name: arm-none-eabi-gcc

--- a/.github/workflows/rp2_port.yml
+++ b/.github/workflows/rp2_port.yml
@@ -24,7 +24,7 @@ jobs:
       run: make -j $(nproc) -C mpy-cross
     - name: Build ${{ matrix.board }}
       run: make -j $(nproc) -C ports/rp2 BOARD=${{ matrix.board }} USER_C_MODULES=../../user_modules/lv_binding_micropython/bindings.cmake
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: ${{ env.GITHUB_EVENT_NAME }} == 'push'
       with:
         name: ${{ matrix.board }}.hex

--- a/.github/workflows/rp2_port.yml
+++ b/.github/workflows/rp2_port.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         board: [PICO]

--- a/.github/workflows/stm32_port.yml
+++ b/.github/workflows/stm32_port.yml
@@ -22,7 +22,7 @@ jobs:
       run: make -j $(nproc) -C mpy-cross
     - name: Build ${{ matrix.board }}
       run: make -j $(nproc) -C ports/stm32 BOARD=${{ matrix.board }}
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       if: ${{ env.GITHUB_EVENT_NAME }} == 'push'
       with:
         name: ${{ matrix.board }}.hex

--- a/.github/workflows/stm32_port.yml
+++ b/.github/workflows/stm32_port.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         board: [STM32F7DISC]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: arm-none-eabi-gcc
       uses: carlosperate/arm-none-eabi-gcc-action@v1.3.0
       with:

--- a/.github/workflows/stm32_port.yml
+++ b/.github/workflows/stm32_port.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         board: [STM32F7DISC]

--- a/.github/workflows/unix_port.yml
+++ b/.github/workflows/unix_port.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   build:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/unix_port.yml
+++ b/.github/workflows/unix_port.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Build mpy-cross
       run: make -j $(nproc) -C mpy-cross
     - name: Build the unix port
-      run: make -j $(nproc) -C ports/unix DEBUG=1
+      run: make -j $(nproc) -C ports/unix DEBUG=1 VARIANT=lvgl
     - name: Run tests
       run: |
         export XDG_RUNTIME_DIR=/tmp

--- a/.github/workflows/unix_port.yml
+++ b/.github/workflows/unix_port.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install Dependencies
       run: |
         sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu `lsb_release -sc` main universe restricted multiverse"


### PR DESCRIPTION
### Summary

In trying to see if the issues I was having locally were also seen in the CI pipeline I noticed that the runners seem to be deprecated for many of the actions authored by the LVGL team, I have updated to use ubuntu latest rather than a pinned version of the OS.

### Testing

<!-- Explain what testing you did, and on which boards/ports. If there are
     boards or ports that you couldn't test, please mention this here as well.

     If you leave this empty then your Pull Request may be closed. -->

This will be tested as part of the PR due to the CI pipelines being triggered

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Switch GitHub Actions runners from ubuntu-20.04 to ubuntu-latest to avoid deprecated environments and keep LVGL actions supported. Applies to js-port-v9, merge-to-js, rp2_port, stm32_port, and unix_port workflows.

<!-- End of auto-generated description by cubic. -->

